### PR TITLE
Divide VCF and gVCF channel, input VCF only for heterozygosity

### DIFF
--- a/subworkflows/local/bcftools_stats_plot/main.nf
+++ b/subworkflows/local/bcftools_stats_plot/main.nf
@@ -5,13 +5,13 @@ include { TAR                   as TAR            }   from '../../../modules/nf-
 
 workflow BCFTOOLS_STATS_PLOT {
     take:
-    vcf_tbi
+    vcfs_tbi     // channel: [ meta, VCF/gVCF, tbi ]
 
     main:
     ch_versions = Channel.empty()
 
     // Call BCFtools stats for general QC
-    BCFTOOLS_STATS( vcf_tbi, [ [:], [] ], [ [:], [] ], [ [:], [] ], [ [:], [] ], [ [:], [] ] )
+    BCFTOOLS_STATS( vcfs_tbi, [ [:], [] ], [ [:], [] ], [ [:], [] ], [ [:], [] ], [ [:], [] ] )
     ch_versions = ch_versions.mix( BCFTOOLS_STATS.out.versions )
 
     PIGZ( BCFTOOLS_STATS.out.stats )

--- a/subworkflows/local/features/main.nf
+++ b/subworkflows/local/features/main.nf
@@ -8,38 +8,45 @@ include { TABIX_BGZIP  as BGZIP                     }   from '../../../modules/n
 
 workflow FEATURES {
     take:
-    vcf                // [ val(meta), vcf ]
-    vcf_tbi
+    samplesheet        // channel: [ meta, VCF/gVCF ]
+    vcfs_tbi           // channel: [ meta, VCF/gVCF, tbi ]
     site_pi_positions  // path to positions file to include or exclude
 
     main:
     ch_versions = Channel.empty()
 
+    // Divide input channel into vcf and gvcf branches
+    samplesheet
+        .branch { meta, data ->
+            vcf  : meta.datatype == "vcf"
+            gvcf : meta.datatype == "gvcf"
+        }
+        .set { vcfs }
+
     // Call VCFtools for per-site (base) nucleotide diversity (originally in variant-calling pipeline)
-    VCFTOOLS_SITE_PI( vcf, site_pi_positions, [] )
+    VCFTOOLS_SITE_PI( samplesheet, site_pi_positions, [] )
     ch_versions = ch_versions.mix( VCFTOOLS_SITE_PI.out.versions )
 
     // Call VCFtools to calculate heterozygosity (originally in variant-calling pipeline)
     // This feature work with VCF files, output of gVCF only contains the header
-    // Plan to divide VCF and gVCF input into different channels, and only include VCF channel for this feature
-    VCFTOOLS_HET( vcf, [], [] )
+    VCFTOOLS_HET( vcfs.vcf, [], [] )
     ch_versions = ch_versions.mix( VCFTOOLS_HET.out.versions )
 
     // Call VCFtools for SNP density
     // the default window size is 1 kb
-    VCFTOOLS_SNP_DENSITY( vcf, [], [] )
+    VCFTOOLS_SNP_DENSITY( samplesheet, [], [] )
     ch_versions = ch_versions.mix( VCFTOOLS_SNP_DENSITY.out.versions )
 
     // Call VCFtools for allele frequency
-    VCFTOOLS_ALLELE_FREQUENCY( vcf, [], [] )
+    VCFTOOLS_ALLELE_FREQUENCY( samplesheet, [], [] )
     ch_versions = ch_versions.mix( VCFTOOLS_ALLELE_FREQUENCY.out.versions )
 
     // Call VCFtools for InDel length distribution
-    VCFTOOLS_INDEL_LENGTH( vcf, [], [] )
+    VCFTOOLS_INDEL_LENGTH( samplesheet, [], [] )
     ch_versions = ch_versions.mix( VCFTOOLS_INDEL_LENGTH.out.versions )
 
     // Call BCFtools for ROH
-    BCFTOOLS_ROH( vcf_tbi, [ [], [] ], [], [], [], [] )
+    BCFTOOLS_ROH( vcfs_tbi, [ [], [] ], [], [], [], [] )
     ch_versions = ch_versions.mix( BCFTOOLS_ROH.out.versions )
 
     // Compress output files

--- a/subworkflows/local/utils_nfcore_variantcomposition_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_variantcomposition_pipeline/main.nf
@@ -165,7 +165,7 @@ def validateInputSamplesheet(input) {
 // Generate methods description for MultiQC
 //
 def toolCitationText() {
-    // TODO nf-core: Optionally add in-text citation tools to this list.
+    // TODO: Optionally add in-text citation tools to this list.
     // Can use ternary operators to dynamically construct based conditions, e.g. params["run_xyz"] ? "Tool (Foo et al. 2023)" : "",
     // Uncomment function in methodsDescriptionText to render in MultiQC report
     def citation_text = [
@@ -177,7 +177,7 @@ def toolCitationText() {
 }
 
 def toolBibliographyText() {
-    // TODO nf-core: Optionally add bibliographic entries to this list.
+    // TODO: Optionally add bibliographic entries to this list.
     // Can use ternary operators to dynamically construct based conditions, e.g. params["run_xyz"] ? "<li>Author (2023) Pub name, Journal, DOI</li>" : "",
     // Uncomment function in methodsDescriptionText to render in MultiQC report
     def reference_text = [
@@ -210,7 +210,7 @@ def methodsDescriptionText(mqc_methods_yaml) {
     meta["tool_citations"] = ""
     meta["tool_bibliography"] = ""
 
-    // TODO nf-core: Only uncomment below if logic in toolCitationText/toolBibliographyText has been filled!
+    // TODO: Only uncomment below if logic in toolCitationText/toolBibliographyText has been filled!
     // meta["tool_citations"] = toolCitationText().replaceAll(", \\.", ".").replaceAll("\\. \\.", ".").replaceAll(", \\.", ".")
     // meta["tool_bibliography"] = toolBibliographyText()
 

--- a/tests/default.nf.test.snap
+++ b/tests/default.nf.test.snap
@@ -1,12 +1,11 @@
 {
     "-profile test": {
         "content": [
-            24,
+            23,
             [
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.bcftools_stats.txt.gz",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.frq",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.gz.tbi",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.het",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.indel.hist",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.plot-vcfstats.pdf",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.plot-vcfstats.tar.gz",
@@ -30,7 +29,6 @@
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.bcftools_stats.txt.gz:md5,5243242b2d7159d8fa40bb024e03b006",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.frq:md5,06e7b4d696872ae1d09f11751cb69ce7",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.gz.tbi:md5,5a2bc05cea8838489bf6a3e48f61743e",
-                "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.het:md5,e9888822bd247b43aeb55d85c82b95eb",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.indel.hist:md5,ac900c010dbb67012cd4371f1034ae44",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.roh:md5,a6d18e59dc9127874e7549f5f6ba8620",
                 "GCA_947369205.1_OX376310.1_CANBKR010000003.1.pacbio.icCanRufa1_deepvariant.g.vcf.sites.pi.gz:md5,2c1cbd686e7b4d16b0e7a13414be65c2",
@@ -49,6 +47,6 @@
             "nf-test": "0.9.2",
             "nextflow": "25.04.6"
         },
-        "timestamp": "2025-09-19T15:40:56.281737134"
+        "timestamp": "2025-09-30T11:53:26.008024513"
     }
 }

--- a/workflows/variantcomposition.nf
+++ b/workflows/variantcomposition.nf
@@ -40,7 +40,7 @@ workflow VARIANTCOMPOSITION {
     // Combine the VCF and TBI channels
     ch_samplesheet
         .join( ch_tbi )
-        .set { ch_vcf_tbi }
+        .set { ch_vcfs_tbi }
 
     //
     // SUBWORKFLOW: FEATURES
@@ -48,7 +48,7 @@ workflow VARIANTCOMPOSITION {
 
     FEATURES (
         ch_samplesheet,
-        ch_vcf_tbi,
+        ch_vcfs_tbi,
         ch_positions
     )
     ch_versions = ch_versions.mix( FEATURES.out.versions )
@@ -58,7 +58,7 @@ workflow VARIANTCOMPOSITION {
     //
 
     BCFTOOLS_STATS_PLOT (
-        ch_vcf_tbi
+        ch_vcfs_tbi
     )
     ch_versions = ch_versions.mix( BCFTOOLS_STATS_PLOT.out.versions )
 


### PR DESCRIPTION
<!--
# sanger-tol/variantcomposition pull request

Many thanks for contributing to sanger-tol/variantcomposition!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.

Learn more about contributing: [CONTRIBUTING.md](https://github.com/sanger-tol/variantcomposition/tree/main/.github/CONTRIBUTING.md)
-->

Heterozygosity analysis by `VCFtools` does not support gVCF input. 

To address this, the input channel is divided into `VCF` and `gVCF` branches, and restrict heterozygosity analysis take the VCF branch only.


## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
